### PR TITLE
Monk X: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14
+WORKDIR /app
+COPY package*.json ./
+RUN yarn install
+COPY . .
+RUN yarn build
+EXPOSE 1337
+CMD ["yarn", "start"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi
+LOAD strapi.yaml

--- a/strapi.yaml
+++ b/strapi.yaml
@@ -1,0 +1,22 @@
+namespace: strapi
+strapi:
+  defines: runnable
+  metadata:
+    name: strapi
+    description: >-
+      Strapi is an open-source, headless CMS written in JavaScript. It allows
+      developers to build APIs quickly and easily for websites, mobile
+      applications, and other digital products.
+    icon: https://strapi.io/assets/strapi-logo-dark.svg
+  containers:
+    strapi:
+      build: .
+      dockerfile: generate
+  variables:
+    jwt-secret:
+      env: JWT_SECRET
+      type: string
+      description: >-
+        Secret key that is used to sign and validate JSON web tokens (JWT) for
+        authentication
+      value: '!!!SETME!!!'


### PR DESCRIPTION
I couldn't make the /tmp/9utjes/Dockerfile work and gave up. You can try to fix it yourself. Here's the error I get:


```
Uploading context file...
Building image...
Failed to build image: image service build failed

```

You can fix the error yourself, push to this branch and then merge the PR. Monk will import the kit ayutomatically.
Alternatively, just close the PR.