### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,57 @@
+namespace: strapi
+
+postgres:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgres
+    description: A powerful, open-source object-relational database system.
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+mysql:
+  defines: runnable
+  inherits: monk-mysql/db
+  metadata:
+    name: mysql
+    description: An open-source relational database management system.
+    icon: https://labs.mysql.com/common/logos/mysql-logo.svg?v2
+  variables:
+    image_tag:
+      type: string
+      value: latest
+      description: ''
+    monk_mysql_database:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_root_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_user:
+      type: string
+      value: monk
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - strapi/postgres
+    - strapi/mysql


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Strapi Application

This PR introduces the containerization and deployment configuration for a Strapi application. Below is a summary of the work done based on the repository structure and the requirements for deploying Strapi as a single, integrated platform.

## Containerization Summary

### Strapi Application
The repository is structured as a monorepo with multiple Node.js packages. However, there are no individual Dockerfiles for the services, and the Strapi application is intended to be deployed as a single service. The docker-compose files indicate that PostgreSQL and MySQL are the required databases for deployment, with separate configurations for development (`docker-compose.dev.yml`) and testing (`docker-compose.test.yml`) environments.

### PostgreSQL and MySQL Services
The docker-compose files define two database services: `postgres` and `mysql`. These services are configured with their respective images and settings for development and testing purposes. No other third-party services are defined in these docker-compose files.

### Dockerfile for Strapi
Attempts to create a Dockerfile for the Strapi service were unsuccessful due to issues with resolving a local workspace dependency (`@strapi/pack-up`) during the `yarn install` step. The Docker build context does not have access to the entire workspace, which is necessary for resolving the dependency. As a result, the Dockerfile creation was halted, and the repository maintainers need to address the handling of local workspace dependencies in the Docker build context or restructure the repository to make it Docker-compatible.

## Monk.io Configuration

### MonkHub Kits
Kits for PostgreSQL and MySQL were found on MonkHub, which will be used for deploying these services.

### `monk.yaml` and `MANIFEST`
The `monk.yaml` file has been created to allow the deployment of the application to monk.io. Additionally, a `MANIFEST` file has been generated, listing the monk.io YAML files that should be deployed to monk.io.

## Conclusion
This PR sets the groundwork for deploying the Strapi application along with its required PostgreSQL and MySQL database services. However, due to the unresolved issue with the Dockerfile creation for Strapi, further action is required by the repository maintainers to enable full containerization and deployment.

---

Please review the changes and provide feedback or additional requirements to complete the containerization and deployment process.