### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,57 @@
+namespace: strapi
+
+postgresql:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgresql
+    description: PostgreSQL database service required by Strapi.
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+mysql:
+  defines: runnable
+  inherits: monk-mysql/db
+  metadata:
+    name: mysql
+    description: MySQL database service required by Strapi.
+    icon: https://labs.mysql.com/common/logos/mysql-logo.svg?v2
+  variables:
+    image_tag:
+      type: string
+      value: latest
+      description: ''
+    monk_mysql_database:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_root_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_user:
+      type: string
+      value: monk
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - strapi/postgresql
+    - strapi/mysql


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Strapi Application

## Summary

This PR introduces the necessary configurations for containerizing and deploying a Strapi headless CMS application. The application is structured into multiple packages, representing core functionalities and various plugins. The main Strapi application is located in the 'core/strapi' directory with entry points for running the application. However, there were no Dockerfiles or containerization configurations present in the repository for the Strapi application or its plugins.

### Key Points:

- The Strapi application is designed as a monolith with multiple internal packages for core features and plugins.
- External services required by the application include PostgreSQL and MySQL databases, as indicated by the 'docker-compose.dev.yml' file.
- Dockerfiles for individual components within the 'packages/' directory were not found, suggesting no pre-configured containerization setup.
- The main Strapi application and its plugins do not have standalone services and are intended to be deployed together.

### Challenges Encountered:

- An attempt was made to create a Dockerfile for the Strapi service. However, the build process failed due to an 'Unsupported URL Type "workspace:"' error related to npm workspaces. This issue persisted despite attempts to handle npm workspaces by copying the entire monorepo into the Docker build context.
- The Dockerfile build process was unsuccessful, and further investigation into the npm version or the configuration of npm workspaces within the Docker context is required.
- Due to the inability to modify the source code or npm configuration, the containerization of the Strapi service could not be completed within this PR.

### External Services:

- **PostgreSQL**: A MonkHub kit for PostgreSQL was found and can be used for deploying the PostgreSQL database service.
- **MySQL**: A MonkHub kit for MySQL was also found and can be used for deploying the MySQL database service.

### Next Steps:

- Resolve the npm workspaces issue to successfully containerize the Strapi service.
- Provide additional instructions or services that need to be configured to work with the PostgreSQL and MySQL databases.

### Generated Files:

- `monk.yaml`: Allows the deployment of the application to monk.io.
- `MANIFEST`: Lists monk.io YAML files that should be deployed to monk.io.

### Conclusion:

This PR lays the groundwork for the deployment of the Strapi application on monk.io. However, due to the challenges encountered with npm workspaces during the Dockerfile build process, further work is required to complete the containerization. Additional details or services that need to be configured are also necessary to proceed with the configuration of the database services.