### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,57 @@
+namespace: strapi
+
+postgres:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgres
+    description: PostgreSQL database service
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+mysql:
+  defines: runnable
+  inherits: monk-mysql/db
+  metadata:
+    name: mysql
+    description: MySQL database service
+    icon: https://labs.mysql.com/common/logos/mysql-logo.svg?v2
+  variables:
+    image_tag:
+      type: string
+      value: latest
+      description: ''
+    monk_mysql_database:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_root_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_user:
+      type: string
+      value: monk
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - strapi/postgres
+    - strapi/mysql


### PR DESCRIPTION
# PR Description: Strapi Application Containerization and Deployment Configuration

## Containerization and Configuration Summary
- I have mapped the services for the Strapi application, identifying that the core Strapi service located in `packages/core/strapi/` needs to be containerized.
- The repository includes a `docker-compose.dev.yml` file that defines two external database services: `postgres` and `mysql`. These services are essential for the Strapi application and are configured to always restart with their respective volumes for data persistence.
- I have searched MonkHub and found kits for both `postgres` and `mysql`, which will be useful for deployment.

## Dockerfile Creation Attempt for Strapi-Core
- I attempted to create a Dockerfile for the `strapi-core` service but encountered a significant blocker: the absence of the `yarn.lock` file in the relevant directories. This file is crucial for Yarn to resolve and install dependencies.
- The `yarn.lock` file was not found in the `packages/core/strapi` directory, the `packages/core` directory, or the root of the repository.
- I found `yarn.lock` files in the `utils/pack-up/examples` path, but they are specific to the examples and not suitable for the `strapi-core` service.
- Due to the missing `yarn.lock` file, I could not complete the Dockerfile for the `strapi-core` service. The repository maintainers need to be notified about this issue and provide the necessary file or instructions on generating it.

## Monk.io Configuration and Deployment
- I have created a Monk configuration file `monk.yaml` and a `MANIFEST` file, which are required for deploying the application using Monk.
- The configuration includes the necessary setup for the `postgres` and `mysql` services, as defined in the `docker-compose.dev.yml` file.

## Next Steps
- The repository maintainers should be contacted to resolve the issue with the missing `yarn.lock` file for the `strapi-core` service.
- Once the `yarn.lock` file is provided or generated, the Dockerfile creation for the `strapi-core` service can be completed.
- After the Dockerfile is successfully built, the Strapi application along with the `postgres` and `mysql` services can be deployed using the provided Monk configuration.

## Instructions for Repository Maintainers
- Please provide the `yarn.lock` file for the `strapi-core` service or instructions on how to generate it.
- After addressing the `yarn.lock` file issue, merge this PR to ensure the application will be re-deployed on each subsequent push with the new containerization and deployment configurations.