### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,57 @@
+namespace: strapi
+
+postgres:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgres
+    description: PostgreSQL database service.
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+mysql:
+  defines: runnable
+  inherits: monk-mysql/db
+  metadata:
+    name: mysql
+    description: MySQL database service.
+    icon: https://labs.mysql.com/common/logos/mysql-logo.svg?v2
+  variables:
+    image_tag:
+      type: string
+      value: latest
+      description: ''
+    monk_mysql_database:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_root_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_user:
+      type: string
+      value: monk
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - strapi/postgres
+    - strapi/mysql


### PR DESCRIPTION
# PR Description: Strapi Application Containerization and Deployment Configuration

## Containerization and Configuration Summary
- I have mapped out the services for the Strapi application repository, which includes a backend CMS with multiple integrated plugins.
- The application requires PostgreSQL and MySQL databases, which are specified in the `docker-compose.dev.yml` and `docker-compose.test.yml` files for development and testing environments, respectively.
- Static assets located in the `public/` directory are served by the Strapi application.
- No Dockerfiles were present in the repository for the Strapi application. Therefore, the next step would be to create a new Dockerfile or use an existing Strapi image from a container registry.

## Monk.io Configuration
- I have added a `monk.yaml` file that contains the Monk.io configuration for the application.
- A `MANIFEST` file has also been added, which is required by Monk.io to list all files containing Monk configurations.
- Kits for PostgreSQL and MySQL have been found on MonkHub and are included in the configuration.

## Next Steps and Instructions
- **Dockerfile for Strapi**: A Dockerfile for the Strapi application is missing. To complete the containerization, a new Dockerfile needs to be created or an existing image from a container registry should be used.
- **Compose Services**: Currently, there are no further instructions or additional services provided to continue the configuration process. The Monk.io configuration is set for the PostgreSQL and MySQL services, but no connections between services are specified yet.
- **Deployment**: Once the Dockerfile for Strapi is created or an existing image is used, and any necessary service connections are configured, the PR can be merged. Subsequent pushes to the repository will trigger re-deployment of the application.

To continue the work:
1. Create or obtain a Dockerfile for the Strapi application.
2. Update the Monk.io configuration if any service connections are required.
3. Merge the PR to enable automatic re-deployment on pushes.