### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,63 @@
+namespace: strapi
+
+postgres:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgres
+    description: PostgreSQL database service for development and testing.
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+mysql:
+  defines: runnable
+  inherits: monk-mysql/db
+  metadata:
+    name: mysql
+    description: MySQL database service for development and testing.
+    icon: https://labs.mysql.com/common/logos/mysql-logo.svg?v2
+  variables:
+    image_tag:
+      type: string
+      value: latest
+      description: ''
+    monk_mysql_database:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_root_password:
+      type: string
+      value: monk
+      description: ''
+    monk_mysql_user:
+      type: string
+      value: monk
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - strapi/postgres
+    - strapi/mysql
+  metadata:
+    name: strapi
+    description: >-
+      Strapi is an open-source headless CMS that is 100% JavaScript/TypeScript,
+      flexible, and fully customizable.
+    icon: https://emojiapi.dev/api/v1/electric_plug.svg


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Strapi Application

## Changes Made

- **Dockerfile Creation Attempt**: I attempted to create a Dockerfile for the Strapi application located in `packages/core/strapi/`. Unfortunately, the build process failed due to the absence of a `yarn.lock` file, which is essential for Yarn to resolve dependencies. The error encountered was related to the package `@strapi/admin-test-utils` not being found.
  
- **Configuration Review**: I reviewed the existing docker-compose files, `docker-compose.dev.yml` and `docker-compose.test.yml`, which define the PostgreSQL and MySQL database services. These services are configured with environment variables and use volumes for data persistence. They are crucial for the Strapi application and must be deployed alongside it.

- **Monk.io Configuration**: I created a Monk configuration file, `monk.yaml`, and a `MANIFEST` file to list all Monk configurations. These files are necessary for deploying the application using Monk.io.

## Encountered Problems

- **Missing `yarn.lock`**: The Dockerfile build could not be completed because the `yarn.lock` file is missing in the `packages/core/strapi` directory. This file is required for Yarn to install dependencies consistently across environments. Without it, the Dockerfile cannot be finalized.

## Next Steps

- **Repository Maintenance**: The repository maintainers need to provide a `yarn.lock` file or instructions on how to proceed without it. Once the `yarn.lock` file is available or an alternative solution is provided, the Dockerfile creation can be revisited and completed.

- **Deployment**: After resolving the `yarn.lock` issue and successfully creating the Dockerfile, the application can be deployed using the provided Monk configurations. The PR can then be merged, and the application will be re-deployed on each subsequent push.

## Instructions for Continuation

1. Add a `yarn.lock` file to the `packages/core/strapi` directory or provide alternative instructions for handling its absence.
2. Re-attempt the Dockerfile build process.
3. Once the Dockerfile is successfully built, merge this PR to enable automatic re-deployment on subsequent pushes.